### PR TITLE
Add method for reading kubernetes token

### DIFF
--- a/esd_services_api_client/boxer/_connector.py
+++ b/esd_services_api_client/boxer/_connector.py
@@ -154,7 +154,7 @@ def select_authentication(auth_provider: str, env: str) -> Optional[BoxerTokenAu
     return None
 
 
-def get_kubernetes_token(cluster_name: str, boxer_base_url: str):
+def get_kubernetes_token(cluster_name: str, boxer_base_url: str) -> BoxerTokenAuth:
     """
     Create Boxer auth based on kubernetes cluster token for ExternalTokenAuth.
     :param cluster_name: Name of the cluster (should match name of Identity provider in boxer configuration)


### PR DESCRIPTION
SneaksAndData/airflow-dags#332

## Scope

Implemented:
 - Add method to read kubernetes auth token and create boxer auth

## Checklist

- [ ] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.
