### PR TITLE
Support additional workgroups and speculative attempts

### DIFF
--- a/esd_services_api_client/crystal/_models.py
+++ b/esd_services_api_client/crystal/_models.py
@@ -102,9 +102,11 @@ class AlgorithmConfiguration(DataClassJsonMixin):
     cpu_limit: Optional[str] = None
     memory_limit: Optional[str] = None
     workgroup: Optional[str] = None
+    additional_workgroups: Optional[Dict[str, str]] = None
     version: Optional[str] = None
     monitoring_parameters: Optional[List[str]] = None
     custom_resources: Optional[Dict[str, str]] = None
+    speculative_attempts: Optional[int] = None
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)


### PR DESCRIPTION
Part of [Speculative Execution](https://github.com/SneaksAndData/crystal/issues/128)

## Scope

Implemented:
 - Extended alg configuration model to support speculative exec and spot workgroups,
 
## Checklist

- [x] GitHub issue exists for this change.
