### PR TITLE
Bump version of GitHub actions

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -20,7 +20,7 @@ jobs:
           architecture: 'x64'
 
       - name: Install Poetry and dependencies
-        uses: SneaksAndData/github-actions/install_poetry@v0.0.19
+        uses: SneaksAndData/github-actions/install_poetry@v0.1.0
         with:
           install_extras: all
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.9.x'
           architecture: 'x64'
       - name: Install Poetry and dependencies
-        uses: SneaksAndData/github-actions/install_poetry@v0.0.21
+        uses: SneaksAndData/github-actions/install_poetry@v0.1.0
         with:
           install_extras: all
       - name: Unit test
@@ -42,7 +42,7 @@ jobs:
           python-version: '3.11.x'
           architecture: 'x64'
       - name: Install Poetry and dependencies
-        uses: SneaksAndData/github-actions/install_poetry@v0.0.21
+        uses: SneaksAndData/github-actions/install_poetry@v0.1.0
         with:
           install_extras: all
       - name: Unit test

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -18,16 +18,14 @@ jobs:
           ref: refs/pull/${{github.event.issue.number}}/merge
           fetch-depth: 0
       - name: Install Poetry and dependencies
-        uses: SneaksAndData/github-actions/install_poetry@v0.0.12
+        uses: SneaksAndData/github-actions/install_poetry@v0.1.0
         with:
           pypi_repo_url: ${{ secrets.AZOPS_PYPI_REPO_URL }}
           pypi_token_username: ${{ secrets.AZOPS_PAT_USER }}
           pypi_token: ${{ secrets.AZOPS_PAT }}
           skip_dependencies: true
       - name: Create package
-        uses: SneaksAndData/github-actions/create_package@v0.0.12
+        uses: SneaksAndData/github-actions/create_package@v0.1.0
         with:
-          pypi_repo_url: ${{ secrets.AZOPS_PYPI_UPLOAD }}
-          pypi_token_username: ${{ secrets.AZOPS_PAT_USER }}
-          pypi_token: ${{ secrets.AZOPS_PAT }}
+          public_package_index_token: ${{ secrets.PYPI_API_TOKEN }}
           package_name: esd_services_api_client

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Create Release
-        uses: SneaksAndData/github-actions/semver_release@v0.0.23
+        uses: SneaksAndData/github-actions/semver_release@v0.1.0
         with:
           major_v: 0
           minor_v: 7


### PR DESCRIPTION
Fixes #59

## Scope

Implemented:
 - Bump version of github actions
 - Addded `public_package_index_token` input into github actions

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
