### PR TITLE
Update Crystal connector to work with v2 API

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,4 +15,4 @@ jobs:
         uses: SneaksAndData/github-actions/semver_release@v0.1.2
         with:
           major_v: 1
-          minor_v: 0
+          minor_v: 1


### PR DESCRIPTION
Adds v1-compatible support for Crystal v2.

## Scope

Implemented:
 - Replaced `base_url` with `scheduler_base_url` and `receiver_base_url`. This will work with v1 out of box, but will require a client upgrade.

## Checklist

- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
