### PR TITLE
Add get beast request runtime info

### DIFF
--- a/esd_services_api_client/beast/v3/_connector.py
+++ b/esd_services_api_client/beast/v3/_connector.py
@@ -254,6 +254,16 @@ class BeastConnector:
 
         return response.json()["lifeCycleStage"]
 
+    def get_request_runtime_info(self, request_id: str) -> Optional[str]:
+        """
+          Returns the runtime information for the given request. Returns None in case error retry fails to resolve within given timeout.
+        :param request_id: A request identifier to read runtime info for.
+        """
+        response = self.http.get(f"{self.base_url}/job/requests/{request_id}")
+        response.raise_for_status()
+
+        return response.json()
+
     def start_job(self, job_params: BeastJobParams, job_name: str) -> Optional[str]:
         """
           Starts a job through Beast.

--- a/esd_services_api_client/beast/v3/_connector.py
+++ b/esd_services_api_client/beast/v3/_connector.py
@@ -254,7 +254,7 @@ class BeastConnector:
 
         return response.json()["lifeCycleStage"]
 
-    def get_request_runtime_info(self, request_id: str) -> Optional[Dict]:
+    def get_request_runtime_info(self, request_id: str) -> Optional[dict]:
         """
           Returns the runtime information for the given request. Returns None in case error retry fails to resolve within given timeout.
         :param request_id: A request identifier to read runtime info for.

--- a/esd_services_api_client/beast/v3/_connector.py
+++ b/esd_services_api_client/beast/v3/_connector.py
@@ -19,7 +19,7 @@
 import json
 from http.client import HTTPException
 from json import JSONDecodeError
-from typing import Optional, Any
+from typing import Optional, Any, Dict
 
 import backoff
 from adapta.utils import doze, session_with_retries
@@ -254,7 +254,7 @@ class BeastConnector:
 
         return response.json()["lifeCycleStage"]
 
-    def get_request_runtime_info(self, request_id: str) -> Optional[str]:
+    def get_request_runtime_info(self, request_id: str) -> Optional[Dict]:
         """
           Returns the runtime information for the given request. Returns None in case error retry fails to resolve within given timeout.
         :param request_id: A request identifier to read runtime info for.

--- a/esd_services_api_client/beast/v3/_connector.py
+++ b/esd_services_api_client/beast/v3/_connector.py
@@ -19,7 +19,7 @@
 import json
 from http.client import HTTPException
 from json import JSONDecodeError
-from typing import Optional, Any, Dict
+from typing import Optional, Any
 
 import backoff
 from adapta.utils import doze, session_with_retries


### PR DESCRIPTION
Fixes/Implements #<issue number>.

## Scope

Implemented:
 - Add get request info method for Beast V3 jobs

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
