### PR TITLE
Enable payload injection in MLA Framework

### DIFF
--- a/esd_services_api_client/nexus/README.md
+++ b/esd_services_api_client/nexus/README.md
@@ -17,7 +17,6 @@ from typing import Dict
 
 import pandas
 from adapta.metrics import MetricsProvider
-from adapta.process_communication import DataSocket
 from adapta.storage.query_enabled_store import QueryEnabledStore
 from injector import inject
 

--- a/esd_services_api_client/nexus/README.md
+++ b/esd_services_api_client/nexus/README.md
@@ -22,6 +22,7 @@ from adapta.storage.query_enabled_store import QueryEnabledStore
 from injector import inject
 
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
+from esd_services_api_client.nexus.abstractions.socket_provider import SocketProvider
 from esd_services_api_client.nexus.core.app_core import Nexus
 from esd_services_api_client.nexus.algorithms import MinimalisticAlgorithm
 from esd_services_api_client.nexus.input import InputReader, InputProcessor
@@ -44,9 +45,9 @@ class XReader(InputReader):
         pass
 
     @inject
-    def __init__(self, store: QueryEnabledStore, metrics_provider: MetricsProvider, logger_factory: LoggerFactory,
+    def __init__(self, store: QueryEnabledStore, metrics_provider: MetricsProvider, logger_factory: LoggerFactory, socket_provider: SocketProvider,
                  *readers: "InputReader"):
-        super().__init__(DataSocket(alias="x", data_path="testx", data_format='delta'), store, metrics_provider, logger_factory, *readers)
+        super().__init__(socket_provider.socket("x"), store, metrics_provider, logger_factory, *readers)
 
     async def _read_input(self) -> PandasDataFrame:
         return pandas.DataFrame([{'a': 1, 'b': 2}, {'a': 2, 'b': 3}])
@@ -60,9 +61,9 @@ class YReader(InputReader):
         pass
 
     @inject
-    def __init__(self, store: QueryEnabledStore, metrics_provider: MetricsProvider, logger_factory: LoggerFactory,
+    def __init__(self, store: QueryEnabledStore, metrics_provider: MetricsProvider, logger_factory: LoggerFactory, socket_provider: SocketProvider,
                  *readers: "InputReader"):
-        super().__init__(DataSocket(alias="y", data_path="testy", data_format='delta'), store, metrics_provider, logger_factory, *readers)
+        super().__init__(socket_provider.socket("y"), store, metrics_provider, logger_factory, *readers)
 
     async def _read_input(self) -> PandasDataFrame:
         return pandas.DataFrame([{'a': 10, 'b': 12}, {'a': 11, 'b': 13}])

--- a/esd_services_api_client/nexus/README.md
+++ b/esd_services_api_client/nexus/README.md
@@ -103,12 +103,13 @@ class MyAlgorithm(MinimalisticAlgorithm):
 
 
 async def main():
-    nexus = Nexus.create() \
+    nexus = await Nexus.create() \
         .add_reader(XReader) \
         .add_reader(YReader) \
         .use_processor(MyInputProcessor) \
-        .use_algorithm(MyAlgorithm)
-
+        .use_algorithm(MyAlgorithm) \
+        .inject_payload()
+    
     await nexus.activate()
     
 

--- a/esd_services_api_client/nexus/README.md
+++ b/esd_services_api_client/nexus/README.md
@@ -13,19 +13,27 @@ Example usage:
 
 ```python
 import asyncio
-from typing import Dict
+import json
+import socketserver
+import threading
+from dataclasses import dataclass
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+from typing import Dict, Optional
 
 import pandas
 from adapta.metrics import MetricsProvider
+from adapta.process_communication import DataSocket
 from adapta.storage.query_enabled_store import QueryEnabledStore
+from dataclasses_json import DataClassJsonMixin
 from injector import inject
 
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
-from esd_services_api_client.nexus.abstractions.socket_provider import SocketProvider
 from esd_services_api_client.nexus.core.app_core import Nexus
 from esd_services_api_client.nexus.algorithms import MinimalisticAlgorithm
 from esd_services_api_client.nexus.input import InputReader, InputProcessor
 from pandas import DataFrame as PandasDataFrame
+
+from esd_services_api_client.nexus.input.payload_reader import AlgorithmPayload
 
 
 async def my_on_complete_func_1(**kwargs):
@@ -35,8 +43,66 @@ async def my_on_complete_func_1(**kwargs):
 async def my_on_complete_func_2(**kwargs):
     pass
 
+@dataclass
+class MyAlgorithmPayload(AlgorithmPayload, DataClassJsonMixin):
+    x: Optional[list[int]] = None
+    y: Optional[list[int]] = None
 
-class XReader(InputReader):
+@dataclass
+class MyAlgorithmPayload2(AlgorithmPayload, DataClassJsonMixin):
+    z: list[int]
+    x: Optional[list[int]] = None
+    y: Optional[list[int]] = None
+
+    def __post_init__(self):
+        pass
+
+class MockRequestHandler(BaseHTTPRequestHandler):
+    """
+    HTTPServer Mock Request handler
+    """
+
+    def __init__(self, request: bytes, client_address: tuple[str, int], server: socketserver.BaseServer):
+        """
+         Initialize request handler
+        :param request:
+        :param client_address:
+        :param server:
+        """
+        self._responses = {
+            "some/payload": (
+                {
+                    # "x": [-1, 0, 2],
+                    # "y": [10, 11, 12],
+                    "z": [1, 2, 3]
+                }, 200)
+        }
+        super().__init__(request, client_address, server)
+
+    def do_GET(self):  # pylint: disable=invalid-name
+        """Handle POST requests"""
+        current_url = self.path.removeprefix("/")
+
+        if current_url not in self._responses:
+            self.send_response(500, "Unknown URL")
+            return
+
+        self.send_response(self._responses[current_url][1])
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(self._responses[current_url][0]).encode("utf-8"))
+
+    def log_request(self, code=None, size=None):
+        """
+         Don't log anything
+        :param code:
+        :param size:
+        :return:
+        """
+        pass
+
+
+class XReader(InputReader[MyAlgorithmPayload]):
     async def _context_open(self):
         pass
 
@@ -44,15 +110,18 @@ class XReader(InputReader):
         pass
 
     @inject
-    def __init__(self, store: QueryEnabledStore, metrics_provider: MetricsProvider, logger_factory: LoggerFactory, socket_provider: SocketProvider,
+    def __init__(self, store: QueryEnabledStore, metrics_provider: MetricsProvider, logger_factory: LoggerFactory,
+                 payload: MyAlgorithmPayload,
                  *readers: "InputReader"):
-        super().__init__(socket_provider.socket("x"), store, metrics_provider, logger_factory, *readers)
+        super().__init__(DataSocket(alias="x", data_path="testx", data_format='delta'), store, metrics_provider,
+                         logger_factory, payload, *readers)
 
     async def _read_input(self) -> PandasDataFrame:
+        self._logger.info("Payload: {payload}", payload=self._payload.to_json())
         return pandas.DataFrame([{'a': 1, 'b': 2}, {'a': 2, 'b': 3}])
 
 
-class YReader(InputReader):
+class YReader(InputReader[MyAlgorithmPayload2]):
     async def _context_open(self):
         pass
 
@@ -60,11 +129,14 @@ class YReader(InputReader):
         pass
 
     @inject
-    def __init__(self, store: QueryEnabledStore, metrics_provider: MetricsProvider, logger_factory: LoggerFactory, socket_provider: SocketProvider,
+    def __init__(self, store: QueryEnabledStore, metrics_provider: MetricsProvider, logger_factory: LoggerFactory,
+                 payload: MyAlgorithmPayload2,
                  *readers: "InputReader"):
-        super().__init__(socket_provider.socket("y"), store, metrics_provider, logger_factory, *readers)
+        super().__init__(DataSocket(alias="y", data_path="testy", data_format='delta'), store, metrics_provider,
+                         logger_factory, payload, *readers)
 
-    async def _read_input(self) -> PandasDataFrame:
+    async def _read_input(self) -> PandasDataFrame:    
+        self._logger.info("Payload: {payload}", payload=self._payload.to_json())
         return pandas.DataFrame([{'a': 10, 'b': 12}, {'a': 11, 'b': 13}])
 
 
@@ -76,7 +148,7 @@ class MyInputProcessor(InputProcessor):
         pass
 
     @inject
-    def __init__(self, x: XReader, y: YReader, metrics_provider: MetricsProvider, logger_factory: LoggerFactory,):
+    def __init__(self, x: XReader, y: YReader, metrics_provider: MetricsProvider, logger_factory: LoggerFactory, ):
         super().__init__(x, y, metrics_provider=metrics_provider, logger_factory=logger_factory)
 
     async def process_input(self, **_) -> Dict[str, PandasDataFrame]:
@@ -95,7 +167,8 @@ class MyAlgorithm(MinimalisticAlgorithm):
         pass
 
     @inject
-    def __init__(self, input_processor: MyInputProcessor, metrics_provider: MetricsProvider, logger_factory: LoggerFactory,):
+    def __init__(self, input_processor: MyInputProcessor, metrics_provider: MetricsProvider,
+                 logger_factory: LoggerFactory, ):
         super().__init__(input_processor, metrics_provider, logger_factory)
 
     async def _run(self, x_ready: PandasDataFrame, y_ready: PandasDataFrame, **kwargs) -> PandasDataFrame:
@@ -103,23 +176,38 @@ class MyAlgorithm(MinimalisticAlgorithm):
 
 
 async def main():
-    nexus = await Nexus.create() \
-        .add_reader(XReader) \
-        .add_reader(YReader) \
-        .use_processor(MyInputProcessor) \
-        .use_algorithm(MyAlgorithm) \
-        .inject_payload()
-    
-    await nexus.activate()
-    
+    """
+     Mock HTTP Server
+    :return:
+    """
+    # NB: http server context here is purely to simulate payload retrieval. You do not need it in your program
+    with ThreadingHTTPServer(("localhost", 9876), MockRequestHandler) as server:
+        server_thread = threading.Thread(target=server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+        
+        # Nexus code starts
+        nexus = await Nexus.create() \
+            .add_reader(XReader) \
+            .add_reader(YReader) \
+            .use_processor(MyInputProcessor) \
+            .use_algorithm(MyAlgorithm) \
+            .inject_payload(MyAlgorithmPayload, MyAlgorithmPayload2)
+
+        await nexus.activate()
+        
+        # Nexus code ends
+        server.shutdown()
+
 
 if __name__ == "__main__":
     asyncio.run(main())
+
 
 ```
 
 Run this code as `sample.py`:
 
 ```shell
-python3 sample.py --sas-uri 'https://localhost' --request-id test
+python3 sample.py --sas-uri http://localhost:9876/some/payload --request-id test
 ```

--- a/esd_services_api_client/nexus/abstractions/nexus_object.py
+++ b/esd_services_api_client/nexus/abstractions/nexus_object.py
@@ -26,7 +26,7 @@ from adapta.metrics import MetricsProvider
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
 
 
-TPayload = TypeVar("TPayload")
+TPayload = TypeVar("TPayload")  # pylint: disable=C0103
 
 
 class NexusObject(Generic[TPayload], ABC):

--- a/esd_services_api_client/nexus/abstractions/nexus_object.py
+++ b/esd_services_api_client/nexus/abstractions/nexus_object.py
@@ -19,13 +19,17 @@
 
 
 from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
 
 from adapta.metrics import MetricsProvider
 
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
 
 
-class NexusObject(ABC):
+TPayload = TypeVar("TPayload")
+
+
+class NexusObject(Generic[TPayload], ABC):
     """
     Base class for all Nexus objects.
     """

--- a/esd_services_api_client/nexus/abstractions/socket_provider.py
+++ b/esd_services_api_client/nexus/abstractions/socket_provider.py
@@ -1,0 +1,48 @@
+"""
+ Socket provider for all data sockets used by algorithms.
+"""
+import json
+
+#  Copyright (c) 2023. ECCO Sneaks & Data
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from typing import final, Optional
+
+from adapta.process_communication import DataSocket
+
+
+@final
+class SocketProvider:
+    """
+    Wraps a socket collection
+    """
+
+    def __init__(self, *sockets: DataSocket):
+        self._sockets = {socket.alias: socket for socket in sockets}
+
+    def socket(self, name: str) -> Optional[DataSocket]:
+        """
+        Retrieve a socket if it exists.
+        """
+        return self._sockets.get(name, None)
+
+    @classmethod
+    def from_serialized(cls, socket_list_ser: str) -> "SocketProvider":
+        return cls(
+            *[
+                DataSocket.from_dict(socket_dict)
+                for socket_dict in json.loads(socket_list_ser)
+            ]
+        )

--- a/esd_services_api_client/nexus/abstractions/socket_provider.py
+++ b/esd_services_api_client/nexus/abstractions/socket_provider.py
@@ -40,6 +40,9 @@ class SocketProvider:
 
     @classmethod
     def from_serialized(cls, socket_list_ser: str) -> "SocketProvider":
+        """
+        Creates a SocketProvider from a list of serialized sockets
+        """
         return cls(
             *[
                 DataSocket.from_dict(socket_dict)

--- a/esd_services_api_client/nexus/core/app_core.py
+++ b/esd_services_api_client/nexus/core/app_core.py
@@ -146,13 +146,19 @@ class Nexus:
         return self
 
     async def inject_payload(self, *payload_types: Type[AlgorithmPayload]) -> "Nexus":
+        """
+        Adds payloads processed into the specified types to the DI container
+        """
         for payload_type in payload_types:
 
-            async def get_payload() -> payload_type:
+            async def get_payload() -> payload_type:  # pylint: disable=W0640
                 async with AlgorithmPayloadReader(
-                    payload_uri=self._run_args.sas_uri, payload_type=payload_type
+                    payload_uri=self._run_args.sas_uri,
+                    payload_type=payload_type,  # pylint: disable=W0640
                 ) as reader:
                     return reader.payload
+
+            # pylint warnings are silenced here because closure is called inside the same loop it is defined, thus each value of a loop variable is used
 
             self._configurator = self._configurator.with_payload((await get_payload()))
         return self

--- a/esd_services_api_client/nexus/core/app_core.py
+++ b/esd_services_api_client/nexus/core/app_core.py
@@ -143,10 +143,10 @@ class Nexus:
         self._algorithm_class = algorithm
         return self
 
-    async def inject_payload(self) -> "Nexus":
-        async def get_payload() -> AlgorithmPayload:
+    async def inject_payload(self, payload_type: Type[AlgorithmPayload]) -> "Nexus":
+        async def get_payload() -> payload_type:
             async with AlgorithmPayloadReader(
-                payload_uri=self._run_args.sas_uri
+                payload_uri=self._run_args.sas_uri, payload_type=payload_type
             ) as reader:
                 return reader.payload
 

--- a/esd_services_api_client/nexus/core/app_core.py
+++ b/esd_services_api_client/nexus/core/app_core.py
@@ -49,8 +49,10 @@ from esd_services_api_client.nexus.algorithms._baseline_algorithm import (
 from esd_services_api_client.nexus.core.app_dependencies import (
     ServiceConfigurator,
 )
+from esd_services_api_client.nexus.input import AlgorithmPayload
 from esd_services_api_client.nexus.input.input_processor import InputProcessor
 from esd_services_api_client.nexus.input.input_reader import InputReader
+from esd_services_api_client.nexus.input.payload_reader import AlgorithmPayloadReader
 
 
 def is_transient_exception(exception: Optional[BaseException]) -> Optional[bool]:
@@ -139,6 +141,16 @@ class Nexus:
         Algorithm to use for this Nexus instance
         """
         self._algorithm_class = algorithm
+        return self
+
+    async def inject_payload(self) -> "Nexus":
+        async def get_payload() -> AlgorithmPayload:
+            async with AlgorithmPayloadReader(
+                payload_uri=self._run_args.sas_uri
+            ) as reader:
+                return reader.payload
+
+        self._configurator = self._configurator.with_payload((await get_payload()))
         return self
 
     async def _submit_result(

--- a/esd_services_api_client/nexus/core/app_core.py
+++ b/esd_services_api_client/nexus/core/app_core.py
@@ -49,10 +49,12 @@ from esd_services_api_client.nexus.algorithms._baseline_algorithm import (
 from esd_services_api_client.nexus.core.app_dependencies import (
     ServiceConfigurator,
 )
-from esd_services_api_client.nexus.input import AlgorithmPayload
 from esd_services_api_client.nexus.input.input_processor import InputProcessor
 from esd_services_api_client.nexus.input.input_reader import InputReader
-from esd_services_api_client.nexus.input.payload_reader import AlgorithmPayloadReader
+from esd_services_api_client.nexus.input.payload_reader import (
+    AlgorithmPayloadReader,
+    AlgorithmPayload,
+)
 
 
 def is_transient_exception(exception: Optional[BaseException]) -> Optional[bool]:
@@ -143,14 +145,16 @@ class Nexus:
         self._algorithm_class = algorithm
         return self
 
-    async def inject_payload(self, payload_type: Type[AlgorithmPayload]) -> "Nexus":
-        async def get_payload() -> payload_type:
-            async with AlgorithmPayloadReader(
-                payload_uri=self._run_args.sas_uri, payload_type=payload_type
-            ) as reader:
-                return reader.payload
+    async def inject_payload(self, *payload_types: Type[AlgorithmPayload]) -> "Nexus":
+        for payload_type in payload_types:
 
-        self._configurator = self._configurator.with_payload((await get_payload()))
+            async def get_payload() -> payload_type:
+                async with AlgorithmPayloadReader(
+                    payload_uri=self._run_args.sas_uri, payload_type=payload_type
+                ) as reader:
+                    return reader.payload
+
+            self._configurator = self._configurator.with_payload((await get_payload()))
         return self
 
     async def _submit_result(

--- a/esd_services_api_client/nexus/core/app_dependencies.py
+++ b/esd_services_api_client/nexus/core/app_dependencies.py
@@ -29,6 +29,7 @@ from injector import Module, singleton, provider
 
 from esd_services_api_client.crystal import CrystalConnector
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
+from esd_services_api_client.nexus.abstractions.socket_provider import SocketProvider
 from esd_services_api_client.nexus.exceptions.startup_error import (
     FatalStartupConfigurationError,
 )
@@ -124,6 +125,22 @@ class StorageClientModule(Module):
 
         return storage_client_class.for_storage_path(
             path=os.getenv("NEXUS__ALGORITHM_OUTPUT_PATH")
+        )
+
+
+class SocketsModule(Module):
+    """
+    Storage client module.
+    """
+
+    @singleton
+    @provider
+    def provide(self) -> SocketProvider:
+        if not "NEXUS__ALGORITHM_INPUT_DATA_SOCKETS" in os.environ:
+            raise FatalStartupConfigurationError("NEXUS__ALGORITHM_INPUT_DATA_SOCKETS")
+
+        return SocketProvider.from_serialized(
+            os.getenv("NEXUS__ALGORITHM_INPUT_DATA_SOCKETS")
         )
 
 

--- a/esd_services_api_client/nexus/core/app_dependencies.py
+++ b/esd_services_api_client/nexus/core/app_dependencies.py
@@ -26,7 +26,7 @@ from typing import final, Type
 from adapta.metrics import MetricsProvider
 from adapta.storage.blob.base import StorageClient
 from adapta.storage.query_enabled_store import QueryEnabledStore
-from injector import Module, singleton, provider
+from injector import Module, singleton, provider, Binder
 
 from esd_services_api_client.crystal import CrystalConnector
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
@@ -37,7 +37,6 @@ from esd_services_api_client.nexus.exceptions.startup_error import (
 from esd_services_api_client.nexus.input.input_processor import InputProcessor
 from esd_services_api_client.nexus.input.input_reader import InputReader
 from esd_services_api_client.nexus.input.payload_reader import (
-    AlgorithmPayloadReader,
     AlgorithmPayload,
 )
 
@@ -203,5 +202,8 @@ class ServiceConfigurator:
         return self
 
     def with_payload(self, payload: AlgorithmPayload) -> "ServiceConfigurator":
-        self._injection_binds.append(AlgorithmPayloadProviderModule(payload=payload))
+        def t(binder: Binder):
+            binder.bind(payload.__class__, to=payload, scope=singleton)
+
+        self._injection_binds.append(t)
         return self

--- a/esd_services_api_client/nexus/core/app_dependencies.py
+++ b/esd_services_api_client/nexus/core/app_dependencies.py
@@ -1,7 +1,6 @@
 """
  Dependency injections.
 """
-import asyncio
 
 #  Copyright (c) 2023. ECCO Sneaks & Data
 #
@@ -140,26 +139,15 @@ class SocketsModule(Module):
     @singleton
     @provider
     def provide(self) -> SocketProvider:
+        """
+        Dependency provider.
+        """
         if not "NEXUS__ALGORITHM_INPUT_DATA_SOCKETS" in os.environ:
             raise FatalStartupConfigurationError("NEXUS__ALGORITHM_INPUT_DATA_SOCKETS")
 
         return SocketProvider.from_serialized(
             os.getenv("NEXUS__ALGORITHM_INPUT_DATA_SOCKETS")
         )
-
-
-class AlgorithmPayloadProviderModule(Module):
-    """
-    Payload reader module.
-    """
-
-    def __init__(self, payload: AlgorithmPayload):
-        self._payload = payload
-
-    @singleton
-    @provider
-    def provide(self) -> AlgorithmPayload:
-        return self._payload
 
 
 @final
@@ -202,8 +190,15 @@ class ServiceConfigurator:
         return self
 
     def with_payload(self, payload: AlgorithmPayload) -> "ServiceConfigurator":
-        def t(binder: Binder):
+        """
+        Adds the specified payload instance to the DI container.
+        """
+
+        def _(binder: Binder):
+            """
+            Dynamic payload binder for the DI
+            """
             binder.bind(payload.__class__, to=payload, scope=singleton)
 
-        self._injection_binds.append(t)
+        self._injection_binds.append(_)
         return self

--- a/esd_services_api_client/nexus/core/app_dependencies.py
+++ b/esd_services_api_client/nexus/core/app_dependencies.py
@@ -1,6 +1,7 @@
 """
  Dependency injections.
 """
+import asyncio
 
 #  Copyright (c) 2023. ECCO Sneaks & Data
 #
@@ -35,6 +36,10 @@ from esd_services_api_client.nexus.exceptions.startup_error import (
 )
 from esd_services_api_client.nexus.input.input_processor import InputProcessor
 from esd_services_api_client.nexus.input.input_reader import InputReader
+from esd_services_api_client.nexus.input.payload_reader import (
+    AlgorithmPayloadReader,
+    AlgorithmPayload,
+)
 
 
 class MetricsModule(Module):
@@ -144,6 +149,20 @@ class SocketsModule(Module):
         )
 
 
+class AlgorithmPayloadProviderModule(Module):
+    """
+    Payload reader module.
+    """
+
+    def __init__(self, payload: AlgorithmPayload):
+        self._payload = payload
+
+    @singleton
+    @provider
+    def provide(self) -> AlgorithmPayload:
+        return self._payload
+
+
 @final
 class ServiceConfigurator:
     """
@@ -181,4 +200,8 @@ class ServiceConfigurator:
         self._injection_binds.append(
             type(f"{input_processor.__name__}Module", (Module,), {})()
         )
+        return self
+
+    def with_payload(self, payload: AlgorithmPayload) -> "ServiceConfigurator":
+        self._injection_binds.append(AlgorithmPayloadProviderModule(payload=payload))
         return self

--- a/esd_services_api_client/nexus/core/app_dependencies.py
+++ b/esd_services_api_client/nexus/core/app_dependencies.py
@@ -25,7 +25,7 @@ from typing import final, Type
 from adapta.metrics import MetricsProvider
 from adapta.storage.blob.base import StorageClient
 from adapta.storage.query_enabled_store import QueryEnabledStore
-from injector import Module, singleton, provider, Binder
+from injector import Module, singleton, provider
 
 from esd_services_api_client.crystal import CrystalConnector
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
@@ -193,12 +193,7 @@ class ServiceConfigurator:
         """
         Adds the specified payload instance to the DI container.
         """
-
-        def _(binder: Binder):
-            """
-            Dynamic payload binder for the DI
-            """
-            binder.bind(payload.__class__, to=payload, scope=singleton)
-
-        self._injection_binds.append(_)
+        self._injection_binds.append(
+            lambda binder: binder.bind(payload.__class__, to=payload, scope=singleton)
+        )
         return self

--- a/esd_services_api_client/nexus/input/input_reader.py
+++ b/esd_services_api_client/nexus/input/input_reader.py
@@ -82,7 +82,14 @@ class InputReader(NexusObject):
         Coroutine that reads the data from external store and converts it to a dataframe.
         """
 
-        @run_time_metrics_async(metric_name="read_input")
+        @run_time_metrics_async(
+            metric_name="read_input",
+            on_finish_message_template="Finished reading {entity} from path {data_path} in {elapsed:.2f}s seconds",
+            template_args={
+                "entity": self._metric_name.upper(),
+                "data_path": self.socket.data_path,
+            },
+        )
         async def _read(**_) -> PandasDataFrame:
             if not self._data:
                 self._data = await self._read_input()

--- a/esd_services_api_client/nexus/input/input_reader.py
+++ b/esd_services_api_client/nexus/input/input_reader.py
@@ -31,6 +31,7 @@ from pandas import DataFrame as PandasDataFrame
 
 from esd_services_api_client.nexus.abstractions.nexus_object import NexusObject
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
+from esd_services_api_client.nexus.input.payload_reader import AlgorithmPayload
 
 
 class InputReader(NexusObject):
@@ -44,6 +45,7 @@ class InputReader(NexusObject):
         store: QueryEnabledStore,
         metrics_provider: MetricsProvider,
         logger_factory: LoggerFactory,
+        payload: AlgorithmPayload,
         *readers: "InputReader"
     ):
         super().__init__(metrics_provider, logger_factory)
@@ -51,6 +53,7 @@ class InputReader(NexusObject):
         self._store = store
         self._data: Optional[PandasDataFrame] = None
         self._readers = readers
+        self._payload = payload
 
     @property
     def data(self) -> Optional[PandasDataFrame]:

--- a/esd_services_api_client/nexus/input/input_reader.py
+++ b/esd_services_api_client/nexus/input/input_reader.py
@@ -29,12 +29,14 @@ from adapta.utils.decorators._logging import run_time_metrics_async
 
 from pandas import DataFrame as PandasDataFrame
 
-from esd_services_api_client.nexus.abstractions.nexus_object import NexusObject
+from esd_services_api_client.nexus.abstractions.nexus_object import (
+    NexusObject,
+    TPayload,
+)
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
-from esd_services_api_client.nexus.input.payload_reader import AlgorithmPayload
 
 
-class InputReader(NexusObject):
+class InputReader(NexusObject[TPayload]):
     """
     Base class for a raw data reader.
     """
@@ -45,7 +47,7 @@ class InputReader(NexusObject):
         store: QueryEnabledStore,
         metrics_provider: MetricsProvider,
         logger_factory: LoggerFactory,
-        payload: AlgorithmPayload,
+        payload: TPayload,
         *readers: "InputReader"
     ):
         super().__init__(metrics_provider, logger_factory)

--- a/esd_services_api_client/nexus/input/payload_reader.py
+++ b/esd_services_api_client/nexus/input/payload_reader.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+
+from adapta.storage.models.format import DictJsonSerializationFormat
+from adapta.utils import session_with_retries
+
+from dataclasses_json import DataClassJsonMixin
+from typing import final, Optional
+
+
+@dataclass
+class AlgorithmPayload(DataClassJsonMixin):
+    """
+    Base class for algorithm payload
+    """
+
+
+@final
+class AlgorithmPayloadReader:
+    async def __aenter__(self):
+        if not self._http:
+            self._http = session_with_retries()
+        http_response = self._http.get(url=self._payload_uri)
+        http_response.raise_for_status()
+        self._payload = DictJsonSerializationFormat().deserialize(http_response.content)
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self._http.close()
+        self._http = None
+
+    def __init__(
+        self,
+        payload_uri: str,
+    ):
+        self._http = session_with_retries()
+        self._payload: Optional[AlgorithmPayload] = None
+        self._payload_uri = payload_uri
+
+    @property
+    def payload_uri(self) -> Optional[str]:
+        return self._payload_uri
+
+    @property
+    def payload(self) -> Optional[AlgorithmPayload]:
+        return self._payload

--- a/esd_services_api_client/nexus/input/payload_reader.py
+++ b/esd_services_api_client/nexus/input/payload_reader.py
@@ -1,10 +1,30 @@
+"""
+ Code infrastructure for manipulating payload received from Crystal SAS URI
+"""
+
+#  Copyright (c) 2023. ECCO Sneaks & Data
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 from dataclasses import dataclass
+
+from typing import final, Optional, Type
 
 from adapta.storage.models.format import DictJsonSerializationFormat
 from adapta.utils import session_with_retries
 
 from dataclasses_json import DataClassJsonMixin
-from typing import final, Optional, Type
 
 
 @dataclass
@@ -16,6 +36,10 @@ class AlgorithmPayload(DataClassJsonMixin):
 
 @final
 class AlgorithmPayloadReader:
+    """
+    Crystal Payload Reader - receives the payload from the URI and deserializes it into the specified type
+    """
+
     async def __aenter__(self):
         if not self._http:
             self._http = session_with_retries()
@@ -38,8 +62,14 @@ class AlgorithmPayloadReader:
 
     @property
     def payload_uri(self) -> Optional[str]:
+        """
+        Uri of the paylod for the algorithm
+        """
         return self._payload_uri
 
     @property
     def payload(self) -> Optional[AlgorithmPayload]:
+        """
+        Payload data deserialized into the user class.
+        """
         return self._payload

--- a/esd_services_api_client/nexus/input/payload_reader.py
+++ b/esd_services_api_client/nexus/input/payload_reader.py
@@ -4,7 +4,7 @@ from adapta.storage.models.format import DictJsonSerializationFormat
 from adapta.utils import session_with_retries
 
 from dataclasses_json import DataClassJsonMixin
-from typing import final, Optional
+from typing import final, Optional, Type
 
 
 @dataclass
@@ -21,20 +21,20 @@ class AlgorithmPayloadReader:
             self._http = session_with_retries()
         http_response = self._http.get(url=self._payload_uri)
         http_response.raise_for_status()
-        self._payload = DictJsonSerializationFormat().deserialize(http_response.content)
+        self._payload = self._payload_type.from_dict(
+            DictJsonSerializationFormat().deserialize(http_response.content)
+        )
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         self._http.close()
         self._http = None
 
-    def __init__(
-        self,
-        payload_uri: str,
-    ):
+    def __init__(self, payload_uri: str, payload_type: Type[AlgorithmPayload]):
         self._http = session_with_retries()
         self._payload: Optional[AlgorithmPayload] = None
         self._payload_uri = payload_uri
+        self._payload_type = payload_type
 
     @property
     def payload_uri(self) -> Optional[str]:

--- a/esd_services_api_client/nexus/input/payload_reader.py
+++ b/esd_services_api_client/nexus/input/payload_reader.py
@@ -1,7 +1,6 @@
 """
  Code infrastructure for manipulating payload received from Crystal SAS URI
 """
-from abc import abstractmethod
 
 #  Copyright (c) 2023. ECCO Sneaks & Data
 #

--- a/esd_services_api_client/nexus/input/payload_reader.py
+++ b/esd_services_api_client/nexus/input/payload_reader.py
@@ -1,6 +1,7 @@
 """
  Code infrastructure for manipulating payload received from Crystal SAS URI
 """
+from abc import abstractmethod
 
 #  Copyright (c) 2023. ECCO Sneaks & Data
 #
@@ -33,6 +34,14 @@ class AlgorithmPayload(DataClassJsonMixin):
     Base class for algorithm payload
     """
 
+    def validate(self):
+        """
+        Optional post-validation of the data. Define this method to analyze class contents after payload has been read and deserialized.
+        """
+
+    def __post_init__(self):
+        self.validate()
+
 
 @final
 class AlgorithmPayloadReader:
@@ -61,7 +70,7 @@ class AlgorithmPayloadReader:
         self._payload_type = payload_type
 
     @property
-    def payload_uri(self) -> Optional[str]:
+    def payload_uri(self) -> str:
         """
         Uri of the paylod for the algorithm
         """

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "adapta"
-version = "2.6.6"
+version = "2.6.7"
 description = "Logging, data connectors, monitoring, secret handling and general lifehacks to make data people lives easier."
 optional = false
 python-versions = ">=3.9,<3.12"
 files = [
-    {file = "adapta-2.6.6-py3-none-any.whl", hash = "sha256:e0baf0fe8e189e4dca3cd9f74831806741153d394cb53942f130fc7c12b7abfc"},
-    {file = "adapta-2.6.6.tar.gz", hash = "sha256:2f78da6d5ba213d20a772a0972a30634e749ab88a2c453b12c21656dae6a8e07"},
+    {file = "adapta-2.6.7-py3-none-any.whl", hash = "sha256:a8f8e18d1cca1002cfe4f700bcfa524872458ab2de0cc0d23874efbbcd7832a3"},
+    {file = "adapta-2.6.7.tar.gz", hash = "sha256:70bd9d2968fdd87afafae22ca535617ddcd138e46127050e85d6d45942f5f0ff"},
 ]
 
 [package.dependencies]
@@ -469,13 +469,13 @@ files = [
 
 [[package]]
 name = "botocore"
-version = "1.34.16"
+version = "1.34.17"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "botocore-1.34.16-py3-none-any.whl", hash = "sha256:e59f3340673abd31e042b494a4bca96e55d232f7d3f8222a40a6273515e25891"},
-    {file = "botocore-1.34.16.tar.gz", hash = "sha256:94697602998dced2ce63321a3dbb2e3ddd477721b376cde41fcca9d3ef069037"},
+    {file = "botocore-1.34.17-py3-none-any.whl", hash = "sha256:7272c39032c6f1d62781e4c8445d9a1d9140c2bf52ba7ee66bf6db559c4b2427"},
+    {file = "botocore-1.34.17.tar.gz", hash = "sha256:e48a662f3a6919219276b55085e8f73c3347966675f55e9d448be30cf79678ee"},
 ]
 
 [package.dependencies]
@@ -3351,4 +3351,4 @@ nexus = ["httpx", "injector"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "0b3e509cf96886522887cb60eb161beb623782db543df691342cf649c803e84d"
+content-hash = "e47bea7e7e8aa2c74566cc63aec6f64156799d25f2321ff68c2a5475ce2509fe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = 'https://github.com/SneaksAndData/esd-services-api-client'
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-adapta = { version = "^2.6.5", extras = ["azure", "storage", "datadog"] }
+adapta = { version = "^2.6.6", extras = ["azure", "storage", "datadog"] }
 dataclasses-json = "^0.6.0"
 pycryptodome = "~3.15"
 azure-identity = { version = "~1.7", optional = true }


### PR DESCRIPTION
Part of #83 

## Scope

Implemented:
 - Enabled payload injection via `inject` library using dynamic bind call
 - Added payload reader that supports async read and deser from the payload uri provided from CLI args

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
