### PR TITLE
Add cache to resolve

### DIFF
--- a/esd_services_api_client/nexus/abstractions/nexus_object.py
+++ b/esd_services_api_client/nexus/abstractions/nexus_object.py
@@ -95,5 +95,8 @@ class NexusObject(Generic[TPayload, TResult], ABC):
         return re.sub(
             r"(?<!^)(?=[A-Z])",
             "_",
-            cls.__name__.lower().replace("reader", "").replace("processor", ""),
+            cls.__name__.lower()
+            .replace("reader", "")
+            .replace("processor", "")
+            .replace("algorithm", ""),
         )

--- a/esd_services_api_client/nexus/abstractions/socket_provider.py
+++ b/esd_services_api_client/nexus/abstractions/socket_provider.py
@@ -22,6 +22,10 @@ from typing import final, Optional
 
 from adapta.process_communication import DataSocket
 
+from esd_services_api_client.nexus.exceptions.startup_error import (
+    FatalStartupConfigurationError,
+)
+
 
 @final
 class ExternalSocketProvider:
@@ -32,11 +36,16 @@ class ExternalSocketProvider:
     def __init__(self, *sockets: DataSocket):
         self._sockets = {socket.alias: socket for socket in sockets}
 
-    def socket(self, name: str) -> Optional[DataSocket]:
+    def socket(self, name: str) -> DataSocket:
         """
         Retrieve a socket if it exists.
         """
-        return self._sockets.get(name, None)
+        if name in self._sockets:
+            return self._sockets[name]
+
+        raise FatalStartupConfigurationError(
+            missing_entry=f"socket with alias `{name}`"
+        )
 
     @classmethod
     def from_serialized(cls, socket_list_ser: str) -> "ExternalSocketProvider":

--- a/esd_services_api_client/nexus/abstractions/socket_provider.py
+++ b/esd_services_api_client/nexus/abstractions/socket_provider.py
@@ -1,7 +1,6 @@
 """
  Socket provider for all data sockets used by algorithms.
 """
-import json
 
 #  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
@@ -18,7 +17,8 @@ import json
 #  limitations under the License.
 #
 
-from typing import final, Optional
+import json
+from typing import final
 
 from adapta.process_communication import DataSocket
 

--- a/esd_services_api_client/nexus/algorithms/_baseline_algorithm.py
+++ b/esd_services_api_client/nexus/algorithms/_baseline_algorithm.py
@@ -1,7 +1,6 @@
 """
  Base algorithm
 """
-import asyncio
 
 #  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #

--- a/esd_services_api_client/nexus/exceptions/startup_error.py
+++ b/esd_services_api_client/nexus/exceptions/startup_error.py
@@ -1,5 +1,5 @@
 """
- Custom exceptions.
+ App startup exceptions.
 """
 
 #  Copyright (c) 2023-2024. ECCO Sneaks & Data

--- a/esd_services_api_client/nexus/input/input_processor.py
+++ b/esd_services_api_client/nexus/input/input_processor.py
@@ -62,6 +62,9 @@ class InputProcessor(NexusObject[TPayload, TResult]):
 
     @property
     def result(self) -> dict[str, TResult]:
+        """
+        Data returned by this processor
+        """
         return self._result
 
     @abstractmethod
@@ -76,10 +79,7 @@ class InputProcessor(NexusObject[TPayload, TResult]):
 
     async def process_input(self, **kwargs) -> dict[str, TResult]:
         """
-        Input processing logic. Implement this method to prepare data for your algorithm code.
-        """
-        """
-        Coroutine that reads the data from external store and converts it to a dataframe.
+        Input processing coroutine. Do not override this method.
         """
 
         @run_time_metrics_async(

--- a/esd_services_api_client/nexus/input/input_processor.py
+++ b/esd_services_api_client/nexus/input/input_processor.py
@@ -1,6 +1,7 @@
 """
  Input processing.
 """
+import asyncio
 
 #  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
@@ -18,8 +19,11 @@
 #
 
 from abc import abstractmethod
+from functools import partial
+from typing import Optional
 
 from adapta.metrics import MetricsProvider
+from adapta.utils.decorators import run_time_metrics_async
 
 from esd_services_api_client.nexus.abstractions.nexus_object import (
     NexusObject,
@@ -27,8 +31,13 @@ from esd_services_api_client.nexus.abstractions.nexus_object import (
     TResult,
 )
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
-from esd_services_api_client.nexus.input._functions import resolve_readers
+from esd_services_api_client.nexus.input._functions import (
+    resolve_readers,
+    resolve_reader_exc_type,
+)
 from esd_services_api_client.nexus.input.input_reader import InputReader
+
+_processor_cache = {}
 
 
 class InputProcessor(NexusObject[TPayload, TResult]):
@@ -46,12 +55,90 @@ class InputProcessor(NexusObject[TPayload, TResult]):
         super().__init__(metrics_provider, logger_factory)
         self._readers = readers
         self._payload = payload
+        self._result: Optional[TResult] = None
 
     async def _read_input(self) -> dict[str, TResult]:
         return await resolve_readers(*self._readers)
 
+    @property
+    def result(self) -> dict[str, TResult]:
+        return self._result
+
     @abstractmethod
+    async def _process_input(self, **kwargs) -> dict[str, TResult]:
+        """
+        Input processing logic. Implement this method to prepare data for your algorithm code.
+        """
+
+    @property
+    def _metric_tags(self) -> dict[str, str]:
+        return {"processor": self.__class__.alias()}
+
     async def process_input(self, **kwargs) -> dict[str, TResult]:
         """
         Input processing logic. Implement this method to prepare data for your algorithm code.
         """
+        """
+        Coroutine that reads the data from external store and converts it to a dataframe.
+        """
+
+        @run_time_metrics_async(
+            metric_name="input_process",
+            on_finish_message_template="Finished processing {processor} in {elapsed:.2f}s seconds",
+            template_args={
+                "processor": self.__class__.alias().upper(),
+            },
+        )
+        async def _process(**_) -> dict[str, TResult]:
+            return await self._process_input(**kwargs)
+
+        if self._result is None:
+            self._result = await partial(
+                _process,
+                metric_tags=self._metric_tags,
+                metrics_provider=self._metrics_provider,
+                logger=self._logger,
+            )()
+
+        return self._result
+
+
+async def resolve_processors(
+    *processors: InputProcessor[TPayload, TResult], **kwargs
+) -> dict[str, dict[str, TResult]]:
+    """
+    Concurrently resolve `result` property of all processors by invoking their `process_input` method.
+    """
+
+    def get_result(alias: str, completed_task: asyncio.Task) -> dict[str, TResult]:
+        reader_exc = completed_task.exception()
+        if reader_exc:
+            raise resolve_reader_exc_type(reader_exc)(alias, reader_exc) from reader_exc
+
+        return completed_task.result()
+
+    async def _process(input_processor: InputProcessor):
+        async with input_processor as instance:
+            result = await instance.process_input(**kwargs)
+            _processor_cache[input_processor.__class__.alias()] = result
+        return result
+
+    cached = {
+        processor.__class__.alias(): processor.result
+        for processor in processors
+        if processor.__class__.alias() in _processor_cache
+    }
+    if len(cached) == len(processors):
+        return cached
+
+    process_tasks: dict[str, asyncio.Task] = {
+        processor.__class__.alias(): asyncio.create_task(_process(processor))
+        for processor in processors
+        if processor.__class__.alias() not in _processor_cache
+    }
+    if len(process_tasks) > 0:
+        await asyncio.wait(fs=process_tasks.values())
+
+    return {
+        alias: get_result(alias, task) for alias, task in process_tasks.items()
+    } | cached

--- a/esd_services_api_client/nexus/input/input_reader.py
+++ b/esd_services_api_client/nexus/input/input_reader.py
@@ -57,6 +57,9 @@ class InputReader(NexusObject[TPayload, TResult]):
 
     @property
     def data(self) -> Optional[TResult]:
+        """
+        Data returned by this reader
+        """
         return self._data
 
     @abstractmethod
@@ -71,7 +74,7 @@ class InputReader(NexusObject[TPayload, TResult]):
 
     async def read(self) -> TResult:
         """
-        Coroutine that reads the data from external store and converts it to a dataframe.
+        Coroutine that reads the data from external store and converts it to a dataframe, or generates data locally. Do not override this method.
         """
 
         @run_time_metrics_async(

--- a/esd_services_api_client/nexus/input/input_reader.py
+++ b/esd_services_api_client/nexus/input/input_reader.py
@@ -55,6 +55,10 @@ class InputReader(NexusObject[TPayload, TResult]):
         self._readers = readers
         self._payload = payload
 
+    @property
+    def data(self) -> Optional[TResult]:
+        return self._data
+
     @abstractmethod
     async def _read_input(self) -> TResult:
         """
@@ -71,7 +75,7 @@ class InputReader(NexusObject[TPayload, TResult]):
         """
 
         @run_time_metrics_async(
-            metric_name="read_input",
+            metric_name="input_read",
             on_finish_message_template="Finished reading {entity} from path {data_path} in {elapsed:.2f}s seconds"
             if self.socket
             else "Finished reading {entity} in {elapsed:.2f}s seconds",


### PR DESCRIPTION
Part of #85 

## Scope

Implemented:
 - Added global cache to readers and processor resolve functions
 - Added implict profiling for processors and algorithm runs
 - Added graceful failure to socket provider when fetching non-existing socket

## Checklist

- [x] GitHub issue exists for this change.
