### PR TITLE
Implement remote/forked runs

### DIFF
--- a/esd_services_api_client/nexus/algorithms/_remote_algorithm.py
+++ b/esd_services_api_client/nexus/algorithms/_remote_algorithm.py
@@ -1,0 +1,116 @@
+"""
+ Remotely executed algorithm
+"""
+
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+from abc import abstractmethod
+from functools import reduce, partial
+
+from adapta.metrics import MetricsProvider
+from adapta.utils.decorators import run_time_metrics_async
+
+from esd_services_api_client.crystal import CrystalConnector, AlgorithmConfiguration
+from esd_services_api_client.nexus.abstractions.nexus_object import (
+    NexusObject,
+    TPayload,
+    AlgorithmResult,
+)
+from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
+from esd_services_api_client.nexus.input.input_processor import (
+    InputProcessor,
+    resolve_processors,
+)
+from esd_services_api_client.nexus.input.payload_reader import AlgorithmPayload
+
+
+class RemoteAlgorithm(NexusObject[TPayload, AlgorithmResult]):
+    """
+    Base class for all algorithm implementations.
+    """
+
+    def __init__(
+        self,
+        metrics_provider: MetricsProvider,
+        logger_factory: LoggerFactory,
+        remote_client: CrystalConnector,
+        remote_name: str,
+        remote_config: AlgorithmConfiguration,
+        *input_processors: InputProcessor,
+    ):
+        super().__init__(metrics_provider, logger_factory)
+        self._input_processors = input_processors
+        self._remote_client = remote_client
+        self._remote_name = remote_name
+        self._remote_config = remote_config
+
+    @abstractmethod
+    def _generate_tag(self) -> str:
+        """
+        Generates a submission tag.
+        """
+
+    @abstractmethod
+    def _transform_submission_result(
+        self, request_id: str, tag: str
+    ) -> AlgorithmResult:
+        """
+        Called after submitting a remote run. Use this to enrich your output with remote run id and tag.
+        """
+
+    @abstractmethod
+    async def _run(self, **kwargs) -> AlgorithmPayload:
+        """
+        Core logic for this algorithm. Implementing this method is mandatory.
+        """
+
+    @property
+    def _metric_tags(self) -> dict[str, str]:
+        return {"algorithm": self.__class__.alias()}
+
+    async def run(self, **kwargs) -> AlgorithmResult:
+        """
+        Coroutine that executes the algorithm logic.
+        """
+
+        @run_time_metrics_async(
+            metric_name="algorthm_run",
+            on_finish_message_template="Launched a new remote {algorithm} in {elapsed:.2f}s seconds",
+            template_args={
+                "algorithm": self.__class__.alias().upper(),
+            },
+        )
+        async def _measured_run(**run_args) -> AlgorithmResult:
+            payload = await self._run(**run_args)
+            tag = self._generate_tag()
+            request_id = self._remote_client.create_run(
+                algorithm=self._remote_name,
+                payload=payload.to_dict(),
+                custom_config=self._remote_config,
+                tag=tag,
+            )
+            return self._transform_submission_result(request_id, tag)
+
+        results = await resolve_processors(*self._input_processors, **kwargs)
+
+        return await partial(
+            _measured_run,
+            **reduce(lambda a, b: a | b, [result for _, result in results.items()]),
+            metric_tags=self._metric_tags,
+            metrics_provider=self._metrics_provider,
+            logger=self._logger,
+        )()

--- a/esd_services_api_client/nexus/algorithms/forked_algorithm.py
+++ b/esd_services_api_client/nexus/algorithms/forked_algorithm.py
@@ -1,0 +1,99 @@
+"""
+ Remotely executed algorithm
+"""
+import asyncio
+
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+from abc import abstractmethod
+from functools import reduce, partial
+
+from adapta.metrics import MetricsProvider
+from adapta.utils.decorators import run_time_metrics_async
+
+from esd_services_api_client.nexus.abstractions.nexus_object import (
+    NexusObject,
+    TPayload,
+    AlgorithmResult,
+)
+from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
+from esd_services_api_client.nexus.algorithms._remote_algorithm import RemoteAlgorithm
+from esd_services_api_client.nexus.input.input_processor import (
+    InputProcessor,
+    resolve_processors,
+)
+
+
+class ForkedAlgorithm(NexusObject[TPayload, AlgorithmResult]):
+    """
+    Forked algorithm is an algorithm that returns a result (main scenario run) and then fires off one or more forked runs
+    with different configurations as specified in fork class implementation.
+
+    Forked algorithm only awaits scheduling of forked runs, but never their results.
+    """
+
+    def __init__(
+        self,
+        metrics_provider: MetricsProvider,
+        logger_factory: LoggerFactory,
+        forks: list[RemoteAlgorithm],
+        *input_processors: InputProcessor,
+    ):
+        super().__init__(metrics_provider, logger_factory)
+        self._input_processors = input_processors
+        assert len(forks) > 0, "Forked algorithm must define one or more forks"
+        self._forks = forks
+
+    @abstractmethod
+    async def _run(self, **kwargs) -> AlgorithmResult:
+        """
+        Core logic for this algorithm. Implementing this method is mandatory.
+        """
+
+    @property
+    def _metric_tags(self) -> dict[str, str]:
+        return {"algorithm": self.__class__.alias()}
+
+    async def run(self, **kwargs) -> AlgorithmResult:
+        """
+        Coroutine that executes the algorithm logic.
+        """
+
+        @run_time_metrics_async(
+            metric_name="algorthm_run",
+            on_finish_message_template="Launched a new remote {algorithm} in {elapsed:.2f}s seconds",
+            template_args={
+                "algorithm": self.__class__.alias().upper(),
+            },
+        )
+        async def _measured_run(**run_args) -> AlgorithmResult:
+            return await self._run(**run_args)
+
+        results = await resolve_processors(*self._input_processors, **kwargs)
+
+        run_result = await partial(
+            _measured_run,
+            **reduce(lambda a, b: a | b, [result for _, result in results.items()]),
+            metric_tags=self._metric_tags,
+            metrics_provider=self._metrics_provider,
+            logger=self._logger,
+        )()
+
+        # now await callback scheduling
+        await asyncio.wait([fork.run(**kwargs) for fork in self._forks])
+
+        return run_result

--- a/esd_services_api_client/nexus/algorithms/forked_algorithm.py
+++ b/esd_services_api_client/nexus/algorithms/forked_algorithm.py
@@ -1,7 +1,6 @@
 """
  Remotely executed algorithm
 """
-import asyncio
 
 #  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
@@ -18,7 +17,7 @@ import asyncio
 #  limitations under the License.
 #
 
-
+import asyncio
 from abc import abstractmethod
 from functools import reduce, partial
 
@@ -32,6 +31,9 @@ from esd_services_api_client.nexus.abstractions.nexus_object import (
 )
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
 from esd_services_api_client.nexus.algorithms._remote_algorithm import RemoteAlgorithm
+from esd_services_api_client.nexus.exceptions.startup_error import (
+    FatalAlgorithmConfigurationError,
+)
 from esd_services_api_client.nexus.input.input_processor import (
     InputProcessor,
     resolve_processors,
@@ -55,7 +57,11 @@ class ForkedAlgorithm(NexusObject[TPayload, AlgorithmResult]):
     ):
         super().__init__(metrics_provider, logger_factory)
         self._input_processors = input_processors
-        assert len(forks) > 0, "Forked algorithm must define one or more forks"
+        if len(forks) > 0:
+            raise FatalAlgorithmConfigurationError(
+                message="Forked algorithm must define one or more forks",
+                algorithm_class=self.__class__,
+            )
         self._forks = forks
 
     @abstractmethod
@@ -75,7 +81,7 @@ class ForkedAlgorithm(NexusObject[TPayload, AlgorithmResult]):
 
         @run_time_metrics_async(
             metric_name="algorthm_run",
-            on_finish_message_template="Launched a new remote {algorithm} in {elapsed:.2f}s seconds",
+            on_finish_message_template="Finished running algorithm {algorithm} in {elapsed:.2f}s seconds",
             template_args={
                 "algorithm": self.__class__.alias().upper(),
             },

--- a/esd_services_api_client/nexus/algorithms/forked_algorithm.py
+++ b/esd_services_api_client/nexus/algorithms/forked_algorithm.py
@@ -31,9 +31,6 @@ from esd_services_api_client.nexus.abstractions.nexus_object import (
 )
 from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
 from esd_services_api_client.nexus.algorithms._remote_algorithm import RemoteAlgorithm
-from esd_services_api_client.nexus.exceptions.startup_error import (
-    FatalAlgorithmConfigurationError,
-)
 from esd_services_api_client.nexus.input.input_processor import (
     InputProcessor,
     resolve_processors,

--- a/esd_services_api_client/nexus/exceptions/startup_error.py
+++ b/esd_services_api_client/nexus/exceptions/startup_error.py
@@ -1,6 +1,7 @@
 """
  App startup exceptions.
 """
+from typing import Type
 
 #  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
@@ -46,3 +47,17 @@ class FatalStartupConfigurationError(FatalNexusError):
 
     def __str__(self) -> str:
         return f"Algorithm initialization failed due to a missing configuration entry: {self._missing_entry}."
+
+
+class FatalAlgorithmConfigurationError(FatalNexusError):
+    """
+    Service configuration error that shuts down the Nexus.
+    """
+
+    def __init__(self, message: str, algorithm_class: Type):
+        super().__init__()
+        self._message = message
+        self._type_name = str(algorithm_class)
+
+    def __str__(self) -> str:
+        return f"Algorithm {self._type_name} misconfigured: {self._message}."


### PR DESCRIPTION
Implements #105 

## Scope

Implemented:
 - Added `RemoteAlgorithm` allowing to initiate another algorithm from an existing algorithm
 - Added `ForkedAlgorithm` which allows building chained executions of multiple instances of the same algorithm with different configurations

## Checklist

- [x] GitHub issue exists for this change.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
