### PR TITLE
Implement telemetry recording

### DIFF
--- a/esd_services_api_client/nexus/abstractions/nexus_object.py
+++ b/esd_services_api_client/nexus/abstractions/nexus_object.py
@@ -53,7 +53,7 @@ TResult = TypeVar(  # pylint: disable=C0103
 )
 
 
-class NexusObject(Generic[TPayload, TResult], ABC):
+class NexusCoreObject(ABC):
     """
     Base class for all Nexus objects.
     """
@@ -86,6 +86,12 @@ class NexusObject(Generic[TPayload, TResult], ABC):
         """
         Optional actions to perform on context closure.
         """
+
+
+class NexusObject(Generic[TPayload, TResult], NexusCoreObject, ABC):
+    """
+    Base class for all Nexus objects.
+    """
 
     @classmethod
     def alias(cls) -> str:

--- a/esd_services_api_client/nexus/algorithms/_baseline_algorithm.py
+++ b/esd_services_api_client/nexus/algorithms/_baseline_algorithm.py
@@ -1,7 +1,6 @@
 """
  Base algorithm
 """
-
 #  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-
 
 from abc import abstractmethod
 from functools import partial
@@ -51,6 +49,14 @@ class BaselineAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         super().__init__(metrics_provider, logger_factory)
         self._input_processors = input_processors
         self._cache = cache
+        self._inputs: dict = {}
+
+    @property
+    def inputs(self) -> dict:
+        """
+        Inputs generated for this algorithm run.
+        """
+        return self._inputs
 
     @abstractmethod
     async def _run(self, **kwargs) -> AlgorithmResult:
@@ -77,11 +83,11 @@ class BaselineAlgorithm(NexusObject[TPayload, AlgorithmResult]):
         async def _measured_run(**run_args):
             return await self._run(**run_args)
 
-        results = await self._cache.resolve(*self._input_processors, **kwargs)
+        self._inputs = await self._cache.resolve(*self._input_processors, **kwargs)
 
         return await partial(
             _measured_run,
-            **results,
+            **self._inputs,
             metric_tags=self._metric_tags,
             metrics_provider=self._metrics_provider,
             logger=self._logger,

--- a/esd_services_api_client/nexus/algorithms/minimalistic.py
+++ b/esd_services_api_client/nexus/algorithms/minimalistic.py
@@ -45,5 +45,8 @@ class MinimalisticAlgorithm(BaselineAlgorithm[TPayload], ABC):
         cache: InputCache,
     ):
         super().__init__(
-            metrics_provider, logger_factory, *input_processors, cache=cache
+            metrics_provider,
+            logger_factory,
+            *input_processors,
+            cache=cache,
         )

--- a/esd_services_api_client/nexus/core/app_dependencies.py
+++ b/esd_services_api_client/nexus/core/app_dependencies.py
@@ -44,6 +44,7 @@ from esd_services_api_client.nexus.input.input_reader import InputReader
 from esd_services_api_client.nexus.input.payload_reader import (
     AlgorithmPayload,
 )
+from esd_services_api_client.nexus.telemetry.recorder import TelemetryRecorder
 
 
 @final
@@ -195,6 +196,7 @@ class ServiceConfigurator:
             StorageClientModule(),
             ExternalSocketsModule(),
             CacheModule(),
+            type(f"{TelemetryRecorder.__name__}Module", (Module,), {})(),
         ]
 
     @property

--- a/esd_services_api_client/nexus/telemetry/recorder.py
+++ b/esd_services_api_client/nexus/telemetry/recorder.py
@@ -1,0 +1,97 @@
+"""
+ Telemetry recording module.
+"""
+import asyncio
+import os
+from functools import partial
+from typing import final
+
+import pandas as pd
+from adapta.metrics import MetricsProvider
+from adapta.process_communication import DataSocket
+from adapta.storage.blob.base import StorageClient
+from adapta.storage.models.format import (
+    DictJsonSerializationFormat,
+    DataFrameParquetSerializationFormat,
+)
+from injector import inject, singleton
+
+from esd_services_api_client.nexus.abstractions.logger_factory import LoggerFactory
+from esd_services_api_client.nexus.abstractions.nexus_object import NexusCoreObject
+
+
+@final
+@singleton
+class TelemetryRecorder(NexusCoreObject):
+    """
+    Class for instantiating a telemetry recorder that will save all algorithm inputs (run method arguments) to a persistent location.
+    """
+
+    async def _context_open(self):
+        pass
+
+    async def _context_close(self):
+        pass
+
+    @inject
+    def __init__(
+        self,
+        storage_client: StorageClient,
+        metrics_provider: MetricsProvider,
+        logger_factory: LoggerFactory,
+    ):
+        super().__init__(metrics_provider, logger_factory)
+        self._storage_client = storage_client
+        self._telemetry_base_path = os.getenv("NEXUS__TELEMETRY_PATH")
+
+    async def record(self, run_id: str, **telemetry_args):
+        """
+        Record all data in telemetry args for the provided run_id.
+        """
+
+        async def _record(
+            entity_to_record: pd.DataFrame | dict,
+            entity_name: str,
+            **_,
+        ) -> None:
+            self._logger.debug(
+                "Recording telemetry for {entity_name} in the run {run_id}",
+                entity_name=entity_name,
+                run_id=run_id,
+            )
+            self._storage_client.save_data_as_blob(
+                data=entity_to_record,
+                blob_path=DataSocket(
+                    alias="telemetry",
+                    data_path=f"{self._telemetry_base_path}/{entity_name}/{run_id}",
+                    data_format="null",
+                ).parse_data_path(),
+                serialization_format=DictJsonSerializationFormat
+                if isinstance(entity_to_record, dict)
+                else DataFrameParquetSerializationFormat,
+                overwrite=True,
+            )
+
+        telemetry_tasks = [
+            asyncio.create_task(
+                partial(
+                    _record,
+                    entity_to_record=telemetry_value,
+                    entity_name=telemetry_key,
+                    run_id=run_id,
+                )()
+            )
+            for telemetry_key, telemetry_value in telemetry_args.items()
+        ]
+
+        done, pending = await asyncio.wait(telemetry_tasks)
+        if len(pending) > 0:
+            self._logger.warning(
+                "Some telemetry recording operations did not complete within specified time. This run might lack observability coverage."
+            )
+        for done_telemetry_task in done:
+            telemetry_exc = done_telemetry_task.exception()
+            if telemetry_exc:
+                self._logger.warning(
+                    "Telemetry recoding failed", exception=telemetry_exc
+                )


### PR DESCRIPTION
Part of #83 

## Scope

Implemented:
 - Added `TelemetryRecorder` class that is implicitly used to save all algorithm inputs to a persistent location after the main run has concluded

Additional changes:
- Added `NexusCoreObject` to allow contextual logger activation for classes that do not operate on payload/produce results

## Checklist

- [x] GitHub issue exists for this change.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
