### PR TITLE
Add cancelled lifecycle stage to crystal connector

### DIFF
--- a/esd_services_api_client/crystal/_connector.py
+++ b/esd_services_api_client/crystal/_connector.py
@@ -125,6 +125,7 @@ class CrystalConnector:
             RequestLifeCycleStage.FAILED,
             RequestLifeCycleStage.SCHEDULING_TIMEOUT,
             RequestLifeCycleStage.DEADLINE_EXCEEDED,
+            RequestLifeCycleStage.CANCELLED,
         ]
 
     @classmethod

--- a/esd_services_api_client/crystal/_models.py
+++ b/esd_services_api_client/crystal/_models.py
@@ -36,6 +36,7 @@ class RequestLifeCycleStage(Enum):
     SCHEDULING_TIMEOUT = "SCHEDULING_TIMEOUT"
     DEADLINE_EXCEEDED = "DEADLINE_EXCEEDED"
     THROTTLED = "THROTTLED"
+    CANCELLED = "CANCELLED"
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)

--- a/tests/test_crystal_connector.py
+++ b/tests/test_crystal_connector.py
@@ -122,6 +122,13 @@ def test_crystal_read_input(mocker, serializer: Type[SerializationFormat], data:
         [
             RequestLifeCycleStage.DEADLINE_EXCEEDED,
         ],
+        [
+            RequestLifeCycleStage.CANCELLED,
+        ],
+        [
+            RequestLifeCycleStage.RUNNING,
+            RequestLifeCycleStage.CANCELLED,
+        ],
     ],
 )
 def test_await_runs_request_id(mocker, request_statuses):


### PR DESCRIPTION
Fixes/Implements #<issue number>.

## Scope

Implemented:
 - Add CANCELLED request lifecycle stage to Crystal Connector -  This is necessary to prevent errors in Crystal orchestrators when solvers are cancelled prior to the orchestrator. This will allow the orchestrator to retrieve a run that has been marked as CANCELLED (https://app.datadoghq.eu/logs?query=%40request_id%3A2e06c711-79ba-4bc5-a0c5-9c8b0ce20792%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAY-bGdNnZZwHcQAAAAAAAAAYAAAAAEFZLWJHZE5uQUFDVzJsTHRDcHZtLXdBQgAAACQAAAAAMDE4ZjliMWEtZWIwMC00NzM3LThmYjMtOTRlNTk5YzU4MGEy&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1716207712509&to_ts=1716380512509&live=true)
 
## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
