### PR TITLE
Nexus: Avoid failure when no telemetry tasks are registered

### DIFF
--- a/esd_services_api_client/nexus/telemetry/recorder.py
+++ b/esd_services_api_client/nexus/telemetry/recorder.py
@@ -92,6 +92,8 @@ class TelemetryRecorder(NexusCoreObject):
             )
             for telemetry_key, telemetry_value in telemetry_args.items()
         ]
+        if not telemetry_tasks:
+            return
 
         done, pending = await asyncio.wait(telemetry_tasks)
         if len(pending) > 0:


### PR DESCRIPTION
Currently, the Nexus framework throws an error when no telemetry tasks are registered. Specifically, this occurs when calling asyncio.wait with an empty list (which may happen [here](https://github.com/SneaksAndData/esd-services-api-client/blob/a28e6a875b95b56c6768c909857983c07ec152d7/esd_services_api_client/nexus/telemetry/recorder.py#L96)). As discussed in this [bug](https://bugs.python.org/issue21596), this is the expected behaviour of asyncio.wait.