### PR TITLE
Check status code before retrieving JSON in beast job submission

### DIFF
--- a/esd_services_api_client/beast/v3/_connector.py
+++ b/esd_services_api_client/beast/v3/_connector.py
@@ -106,7 +106,9 @@ class BeastConnector:
             f"{self.base_url}/job/submit/{spark_job_name}", json=request_json
         )
 
-        if submission_result.status_code == 202 and (submission_json := submission_result.json()):
+        if submission_result.status_code == 202 and (
+            submission_json := submission_result.json()
+        ):
             print(
                 f"Beast has accepted the request, stage: {submission_json['lifeCycleStage']}, id: {submission_json['id']}"
             )

--- a/esd_services_api_client/beast/v3/_connector.py
+++ b/esd_services_api_client/beast/v3/_connector.py
@@ -105,9 +105,8 @@ class BeastConnector:
         submission_result = self.http.post(
             f"{self.base_url}/job/submit/{spark_job_name}", json=request_json
         )
-        submission_json = submission_result.json()
 
-        if submission_result.status_code == 202 and submission_json:
+        if submission_result.status_code == 202 and (submission_json := submission_result.json()):
             print(
                 f"Beast has accepted the request, stage: {submission_json['lifeCycleStage']}, id: {submission_json['id']}"
             )


### PR DESCRIPTION
If the beast job submissions fails and does not return JSON, the whole submission fails due to JSON decoding error instead of raising the actual submission error