### PR TITLE
Nexus error handling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,4 +15,4 @@ jobs:
         uses: SneaksAndData/github-actions/semver_release@v0.1.9
         with:
           major_v: 2
-          minor_v: 5
+          minor_v: 6

--- a/esd_services_api_client/nexus/README.md
+++ b/esd_services_api_client/nexus/README.md
@@ -297,7 +297,7 @@ async def main():
         server_thread.daemon = True
         server_thread.start()
         nexus = (
-            await Nexus.create()
+            Nexus.create()
             .add_reader(XReader)
             .add_reader(YReader)
             .use_processor(XProcessor)

--- a/esd_services_api_client/nexus/core/app_core.py
+++ b/esd_services_api_client/nexus/core/app_core.py
@@ -260,8 +260,6 @@ class Nexus:
 
         self._injector = Injector(self._configurator.injection_binds)
 
-        algorithm: BaselineAlgorithm = self._injector.get(self._algorithm_class)
-        telemetry_recorder: TelemetryRecorder = self._injector.get(TelemetryRecorder)
         root_logger: LoggerInterface = self._injector.get(LoggerFactory).create_logger(
             logger_type=self.__class__,
         )
@@ -277,6 +275,9 @@ class Nexus:
             except BaseException as ex:  # pylint: disable=broad-except
                 root_logger.error("Error reading algorithm payload", ex)
                 sys.exit(1)
+
+        algorithm: BaselineAlgorithm = self._injector.get(self._algorithm_class)
+        telemetry_recorder: TelemetryRecorder = self._injector.get(TelemetryRecorder)
 
         root_logger.info(
             "Running algorithm {algorithm} on Nexus version {version}",

--- a/esd_services_api_client/nexus/core/app_core.py
+++ b/esd_services_api_client/nexus/core/app_core.py
@@ -289,7 +289,11 @@ class Nexus:
             self._algorithm_run_task = asyncio.create_task(
                 instance.run(**self._run_args.__dict__)
             )
-            await self._algorithm_run_task
+
+            # avoid exception propagation to main thread, since we need to handle it later
+            await asyncio.wait(
+                [self._algorithm_run_task], return_when=asyncio.FIRST_EXCEPTION
+            )
             ex = self._algorithm_run_task.exception()
 
             if ex is not None:

--- a/esd_services_api_client/nexus/core/app_dependencies.py
+++ b/esd_services_api_client/nexus/core/app_dependencies.py
@@ -247,6 +247,7 @@ class ServiceConfigurator:
             CacheModule(),
             type(f"{TelemetryRecorder.__name__}Module", (Module,), {})(),
         ]
+        self._runtime_injection_binds = []
 
     @property
     def injection_binds(self) -> list:
@@ -254,6 +255,13 @@ class ServiceConfigurator:
         Currently configured injection bindings
         """
         return self._injection_binds
+
+    @property
+    def runtime_injection_binds(self) -> list:
+        """
+        Currently configured injection bindings that are added at runtime
+        """
+        return self._runtime_injection_binds
 
     def with_module(self, module: Type[Module]) -> "ServiceConfigurator":
         """
@@ -277,15 +285,6 @@ class ServiceConfigurator:
         """
         self._injection_binds.append(
             type(f"{input_processor.__name__}Module", (Module,), {})()
-        )
-        return self
-
-    def with_payload(self, payload: AlgorithmPayload) -> "ServiceConfigurator":
-        """
-        Adds the specified payload instance to the DI container.
-        """
-        self._injection_binds.append(
-            lambda binder: binder.bind(payload.__class__, to=payload, scope=singleton)
         )
         return self
 

--- a/esd_services_api_client/nexus/core/app_dependencies.py
+++ b/esd_services_api_client/nexus/core/app_dependencies.py
@@ -42,9 +42,6 @@ from esd_services_api_client.nexus.exceptions.startup_error import (
 )
 from esd_services_api_client.nexus.input.input_processor import InputProcessor
 from esd_services_api_client.nexus.input.input_reader import InputReader
-from esd_services_api_client.nexus.input.payload_reader import (
-    AlgorithmPayload,
-)
 from esd_services_api_client.nexus.telemetry.recorder import TelemetryRecorder
 from esd_services_api_client.nexus.core.serializers import (
     TelemetrySerializer,


### PR DESCRIPTION
Fixes #145 

## Scope

- Moved payload read to runtime DI and change Nexus startup to a normal method rather than a coroutine
- Handle exception on algorithm task run w/o propagating to main thread